### PR TITLE
Read active tab command-line args from file when reappearing

### DIFF
--- a/src/ui/main_window.py
+++ b/src/ui/main_window.py
@@ -12,7 +12,7 @@ import signal
 
 from tools.bluetooth import BluetoothManager
 from utils.arg_parser import ArgParse
-from utils.tab_name import tab_name_from_arguments
+from utils.tab_name import read_tab_from_file, tab_name_from_arguments
 
 gi.require_version("Gtk", "3.0")
 from gi.repository import Gtk, GLib, Gdk  # type: ignore
@@ -26,7 +26,7 @@ from ui.tabs.volume_tab import VolumeTab
 from ui.tabs.wifi_tab import WiFiTab
 from ui.tabs.settings_tab import SettingsTab
 from ui.tabs.usbguard_tab import USBGuardTab
-from utils.settings import load_settings, save_settings, read_tab_from_file
+from utils.settings import load_settings, save_settings
 from utils.logger import LogLevel, Logger
 from ui.css.animations import load_animations_css  # animate_widget_show not used
 from utils.translations import Translation, get_translations

--- a/src/ui/main_window.py
+++ b/src/ui/main_window.py
@@ -1139,17 +1139,14 @@ class BetterControl(Gtk.Window):
             if self.get_property("visible"):
                 self.hide()
             else:
-                def switch_to_tab_from_file():
-                    active_tab = read_tab_from_file()
-
-                    if active_tab and active_tab in self.tab_pages:
-                        page_num = self.tab_pages[active_tab]
-                        self.notebook.set_current_page(page_num)
-                        self.lazy_load_tab(self.notebook, None, page_num)
-
-                GLib.idle_add(switch_to_tab_from_file)
-
                 self.show()
+
+                active_tab = read_tab_from_file()
+
+                if active_tab and active_tab in self.tab_pages:
+                    page_num = self.tab_pages[active_tab]
+                    self.notebook.set_current_page(page_num)
+                    GLib.idle_add(lambda: self.lazy_load_tab(self.notebook, None, page_num))
 
             return False  # Only run once
         

--- a/src/ui/main_window.py
+++ b/src/ui/main_window.py
@@ -559,85 +559,14 @@ class BetterControl(Gtk.Window):
                 active_tab = None
 
             # Set active tab based on command line arguments
-            if (self.arg_parser.find_arg(("-V", "--volume")) or self.arg_parser.find_arg(("-v", ""))) and "Volume" in self.tab_pages:
-                page_num = self.tab_pages["Volume"]
-                self.logging.log(LogLevel.Info, f"Setting active tab to Volume (page {page_num})")
+            requested_tab = tab_name_from_arguments(self.arg_parser)
+            if requested_tab and requested_tab in self.tab_pages:
+                page_num = self.tab_pages[requested_tab]
+                self.logging.log(LogLevel.Info, f"Setting active tab to {requested_tab} (page {page_num})")
                 self.notebook.set_current_page(page_num)
-                active_tab = "Volume"
+                active_tab = requested_tab
                 if self.minimal_mode:
-                    self.set_title(f"Better Control - Volume")
-            elif self.arg_parser.find_arg(("-w", "--wifi")) and "Wi-Fi" in self.tab_pages:
-                page_num = self.tab_pages["Wi-Fi"]
-                self.logging.log(LogLevel.Info, f"Setting active tab to Wi-Fi (page {page_num})")
-                self.notebook.set_current_page(page_num)
-                active_tab = "Wi-Fi"
-                if self.minimal_mode:
-                    self.set_title(f"Better Control - Wi-Fi")
-            elif (
-                self.arg_parser.find_arg(("-a", "--autostart"))
-                and "Autostart" in self.tab_pages
-            ):
-                page_num = self.tab_pages["Autostart"]
-                self.logging.log(LogLevel.Info, f"Setting active tab to Autostart (page {page_num})")
-                self.notebook.set_current_page(page_num)
-                active_tab = "Autostart"
-                if self.minimal_mode:
-                    translated_tab_name = self.tab_name_mapping.get("Autostart", "Autostart") if hasattr(self, 'tab_name_mapping') else "Autostart"
-                    self.set_title(f"Better Control - {translated_tab_name}")
-            elif (
-                self.arg_parser.find_arg(("-b", "--bluetooth"))
-                and "Bluetooth" in self.tab_pages
-            ):
-                page_num = self.tab_pages["Bluetooth"]
-                self.logging.log(LogLevel.Info, f"Setting active tab to Bluetooth (page {page_num})")
-                self.notebook.set_current_page(page_num)
-                active_tab = "Bluetooth"
-                if self.minimal_mode:
-                    translated_tab_name = self.tab_name_mapping.get("Bluetooth", "Bluetooth") if hasattr(self, 'tab_name_mapping') else "Bluetooth"
-                    self.set_title(f"Better Control - {translated_tab_name}")
-            elif (
-                self.arg_parser.find_arg(("-B", "--battery"))
-                and "Battery" in self.tab_pages
-            ):
-                page_num = self.tab_pages["Battery"]
-                self.logging.log(LogLevel.Info, f"Setting active tab to Battery (page {page_num})")
-                self.notebook.set_current_page(page_num)
-                active_tab = "Battery"
-                if self.minimal_mode:
-                    translated_tab_name = self.tab_name_mapping.get("Battery", "Battery") if hasattr(self, 'tab_name_mapping') else "Battery"
-                    self.set_title(f"Better Control - {translated_tab_name}")
-            elif (
-                self.arg_parser.find_arg(("-d", "--display"))
-                and "Display" in self.tab_pages
-            ):
-                page_num = self.tab_pages["Display"]
-                self.logging.log(LogLevel.Info, f"Setting active tab to Display (page {page_num})")
-                self.notebook.set_current_page(page_num)
-                active_tab = "Display"
-                if self.minimal_mode:
-                    translated_tab_name = self.tab_name_mapping.get("Display", "Display") if hasattr(self, 'tab_name_mapping') else "Display"
-                    self.set_title(f"Better Control - {translated_tab_name}")
-            elif (
-                self.arg_parser.find_arg(("-u", "--usbguard"))
-                and "USBGuard" in self.tab_pages
-            ):
-                page_num = self.tab_pages["USBGuard"]
-                self.logging.log(LogLevel.Info, f"Setting active tab to USBGuard (page {page_num})")
-                self.notebook.set_current_page(page_num)
-                active_tab = "USBGuard"
-                if self.minimal_mode:
-                    translated_tab_name = self.tab_name_mapping.get("USBGuard", "USBGuard") if hasattr(self, 'tab_name_mapping') else "USBGuard"
-                    self.set_title(f"Better Control - {translated_tab_name}")
-            elif (
-                self.arg_parser.find_arg(("-p", "--power"))
-                and "Power" in self.tab_pages
-            ):
-                page_num = self.tab_pages["Power"]
-                self.logging.log(LogLevel.Info, f"Setting active tab to Power (page {page_num})")
-                self.notebook.set_current_page(page_num)
-                active_tab = "Power"
-                if self.minimal_mode:
-                    translated_tab_name = self.tab_name_mapping.get("Power", "Power") if hasattr(self, 'tab_name_mapping') else "Power"
+                    translated_tab_name = self.tab_name_mapping.get(requested_tab, requested_tab) if hasattr(self, 'tab_name_mapping') else requested_tab
                     self.set_title(f"Better Control - {translated_tab_name}")
             else:
                 # Default to first tab instead of using last active tab from settings

--- a/src/ui/main_window.py
+++ b/src/ui/main_window.py
@@ -25,7 +25,7 @@ from ui.tabs.volume_tab import VolumeTab
 from ui.tabs.wifi_tab import WiFiTab
 from ui.tabs.settings_tab import SettingsTab
 from ui.tabs.usbguard_tab import USBGuardTab
-from utils.settings import load_settings, save_settings
+from utils.settings import load_settings, save_settings, read_tab_from_file
 from utils.logger import LogLevel, Logger
 from ui.css.animations import load_animations_css  # animate_widget_show not used
 from utils.translations import Translation, get_translations
@@ -1226,7 +1226,15 @@ class BetterControl(Gtk.Window):
             if self.get_property("visible"):
                 self.hide()
             else:
+                active_tab = read_tab_from_file()
+
+                if active_tab and active_tab in self.tab_pages:
+                    page_num = self.tab_pages[active_tab]
+                    self.notebook.set_current_page(page_num)
+                    GLib.idle_add(lambda: self.lazy_load_tab(self.notebook, None, page_num))
+
                 self.show()
+
             return False  # Only run once
         
         GLib.idle_add(toggle_window_visibility)

--- a/src/ui/main_window.py
+++ b/src/ui/main_window.py
@@ -1139,12 +1139,15 @@ class BetterControl(Gtk.Window):
             if self.get_property("visible"):
                 self.hide()
             else:
-                active_tab = read_tab_from_file()
+                def switch_to_tab_from_file():
+                    active_tab = read_tab_from_file()
 
-                if active_tab and active_tab in self.tab_pages:
-                    page_num = self.tab_pages[active_tab]
-                    self.notebook.set_current_page(page_num)
-                    GLib.idle_add(lambda: self.lazy_load_tab(self.notebook, None, page_num))
+                    if active_tab and active_tab in self.tab_pages:
+                        page_num = self.tab_pages[active_tab]
+                        self.notebook.set_current_page(page_num)
+                        self.lazy_load_tab(self.notebook, None, page_num)
+
+                GLib.idle_add(switch_to_tab_from_file)
 
                 self.show()
 

--- a/src/ui/main_window.py
+++ b/src/ui/main_window.py
@@ -12,6 +12,7 @@ import signal
 
 from tools.bluetooth import BluetoothManager
 from utils.arg_parser import ArgParse
+from utils.tab_name import tab_name_from_arguments
 
 gi.require_version("Gtk", "3.0")
 from gi.repository import Gtk, GLib, Gdk  # type: ignore
@@ -221,24 +222,7 @@ class BetterControl(Gtk.Window):
         visibility = self.settings.get("visibility", {})
 
         # Determine active tab (command line args > first visible)
-        active_tab = None
-        # Check command line args first
-        if self.arg_parser.find_arg(("-V", "--volume")) or self.arg_parser.find_arg(("-v", "")):
-            active_tab = "Volume"
-        elif self.arg_parser.find_arg(("-w", "--wifi")):
-            active_tab = "Wi-Fi"
-        elif self.arg_parser.find_arg(("-a", "--autostart")):
-            active_tab = "Autostart"
-        elif self.arg_parser.find_arg(("-b", "--bluetooth")):
-            active_tab = "Bluetooth"
-        elif self.arg_parser.find_arg(("-B", "--battery")):
-            active_tab = "Battery"
-        elif self.arg_parser.find_arg(("-d", "--display")):
-            active_tab = "Display"
-        elif self.arg_parser.find_arg(("-p", "--power")):
-            active_tab = "Power"
-        elif self.arg_parser.find_arg(("-u", "--usbguard")):
-            active_tab = "USBGuard"
+        active_tab = tab_name_from_arguments(self.arg_parser)
         
         # If no args specified, use first visible tab
         if active_tab is None:

--- a/src/utils/settings.py
+++ b/src/utils/settings.py
@@ -7,6 +7,7 @@ from utils.logger import LogLevel, Logger
 CONFIG_DIR = os.environ.get("XDG_CONFIG_HOME", os.path.expanduser("~/.config"))
 CONFIG_PATH = os.path.join(CONFIG_DIR, "better-control")
 SETTINGS_FILE = os.path.join(CONFIG_PATH, "settings.json")
+TAB_FILE = os.path.join(CONFIG_PATH, "tab.txt")
 
 def ensure_config_dir(logging: Logger) -> None:
     """Ensure the config directory exists
@@ -101,3 +102,8 @@ def save_settings(settings: dict, logging: Logger) -> bool:
         except:
             pass
         return False
+
+def read_tab_from_file():
+    if os.path.exists(TAB_FILE):
+        with open(TAB_FILE, 'r', encoding='utf-8') as file:
+            return file.read().strip()

--- a/src/utils/settings.py
+++ b/src/utils/settings.py
@@ -2,14 +2,11 @@
 
 import json
 import os
-from utils.arg_parser import ArgParse
 from utils.logger import LogLevel, Logger
-from utils.tab_name import tab_name_from_arguments
 
 CONFIG_DIR = os.environ.get("XDG_CONFIG_HOME", os.path.expanduser("~/.config"))
 CONFIG_PATH = os.path.join(CONFIG_DIR, "better-control")
 SETTINGS_FILE = os.path.join(CONFIG_PATH, "settings.json")
-TAB_FILE = os.path.join(CONFIG_PATH, "tab.txt")
 
 def ensure_config_dir(logging: Logger) -> None:
     """Ensure the config directory exists
@@ -104,9 +101,3 @@ def save_settings(settings: dict, logging: Logger) -> bool:
         except:
             pass
         return False
-
-def read_tab_from_file():
-    if os.path.exists(TAB_FILE):
-        with open(TAB_FILE, 'r', encoding='utf-8') as file:
-            arg_parser = ArgParse(["better-control"] + file.read().split(" "))
-            return tab_name_from_arguments(arg_parser)

--- a/src/utils/settings.py
+++ b/src/utils/settings.py
@@ -2,7 +2,9 @@
 
 import json
 import os
+from utils.arg_parser import ArgParse
 from utils.logger import LogLevel, Logger
+from utils.tab_name import tab_name_from_arguments
 
 CONFIG_DIR = os.environ.get("XDG_CONFIG_HOME", os.path.expanduser("~/.config"))
 CONFIG_PATH = os.path.join(CONFIG_DIR, "better-control")
@@ -106,4 +108,5 @@ def save_settings(settings: dict, logging: Logger) -> bool:
 def read_tab_from_file():
     if os.path.exists(TAB_FILE):
         with open(TAB_FILE, 'r', encoding='utf-8') as file:
-            return file.read().strip()
+            arg_parser = ArgParse(["better-control"] + file.read().split(" "))
+            return tab_name_from_arguments(arg_parser)

--- a/src/utils/tab_name.py
+++ b/src/utils/tab_name.py
@@ -1,0 +1,24 @@
+from utils.arg_parser import ArgParse
+
+
+def tab_name_from_arguments(arg_parser: ArgParse):
+    active_tab = None
+
+    if arg_parser.find_arg(("-V", "--volume")) or arg_parser.find_arg(("-v", "")):
+        active_tab = "Volume"
+    elif arg_parser.find_arg(("-w", "--wifi")):
+        active_tab = "Wi-Fi"
+    elif arg_parser.find_arg(("-a", "--autostart")):
+        active_tab = "Autostart"
+    elif arg_parser.find_arg(("-b", "--bluetooth")):
+        active_tab = "Bluetooth"
+    elif arg_parser.find_arg(("-B", "--battery")):
+        active_tab = "Battery"
+    elif arg_parser.find_arg(("-d", "--display")):
+        active_tab = "Display"
+    elif arg_parser.find_arg(("-p", "--power")):
+        active_tab = "Power"
+    elif arg_parser.find_arg(("-u", "--usbguard")):
+        active_tab = "USBGuard"
+
+    return active_tab

--- a/src/utils/tab_name.py
+++ b/src/utils/tab_name.py
@@ -1,3 +1,5 @@
+import os
+from pathlib import Path
 from utils.arg_parser import ArgParse
 
 
@@ -22,3 +24,12 @@ def tab_name_from_arguments(arg_parser: ArgParse):
         active_tab = "USBGuard"
 
     return active_tab
+
+def read_tab_from_file():
+    temp_dir = Path("/tmp/better-control")
+    tab_file_path = temp_dir / "tab.txt"
+
+    if os.path.exists(tab_file_path):
+        with open(tab_file_path, 'r', encoding='utf-8') as file:
+            arg_parser = ArgParse(["better-control"] + file.read().split(" "))
+            return tab_name_from_arguments(arg_parser)


### PR DESCRIPTION
Hi,

This one's a bit esoteric, so I understand if you don't want to merge it.

I have multiple icons that trigger better-control and, in continuation of my first PR, would be cool if it would reappear with the corresponding tab open rather than whichever was open last time:

<img width="822" height="450" alt="2025-11-18-230201_hyprshot" src="https://github.com/user-attachments/assets/83f8f96f-fe9a-4f69-9d4a-ce64dccd87da" />

------

There's no way to pass an argument with SIGUSR1, so instead I'm writing to a file in /tmp and have better-control read it when reappearing:

```bash
#!/usr/bin/env bash

PID=`pidof better-control`
if [ -n "$PID" ]; then
  mkdir -p /tmp/better-control
  echo $@ > /tmp/better-control/tab.txt
  kill -SIGUSR1 $PID
else
  better-control $@
fi
```

The script then accepts the same arguments as better-control itself:

```bash
toggle-better-control -w
```

I had to extract the tab argument logic because it's used in two places now, hope `src/utils/tab_name.py` is the right place for it.